### PR TITLE
allow file upload without filename

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -94,8 +94,10 @@ function makeMiddleware (setup) {
 
     // handle files
     busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
-      // don't attach to the files object, if there is no file
-      if (!filename) return fileStream.resume()
+      // filename is not required (https://tools.ietf.org/html/rfc1867) but if
+      // filename not present busboy only treats as file if content type is
+      // application/octet-stream
+      if (!filename) filename = 'undefined'
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && limits.hasOwnProperty('fieldNameSize')) {

--- a/test/files/no-filename.dat
+++ b/test/files/no-filename.dat
@@ -1,0 +1,11 @@
+--99999
+Content-Disposition: form-data; name="textField"
+Content-Type: text/plain; charset=ISO-8859-1
+
+foo
+--99999
+Content-Disposition: form-data; name="fileField"
+Content-Type: application/octet-stream
+
+foo
+--99999--

--- a/test/no-filename.js
+++ b/test/no-filename.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+var fs = require('fs')
+var onFinished = require('on-finished')
+var path = require('path')
+
+var multer = require('../')
+
+describe('File with no filename', function () {
+  var upload
+
+  before(function () {
+    upload = multer()
+  })
+
+  it('should accept file without filename', function (done) {
+    var parser = upload.any()
+
+    var filePath = path.join(__dirname, 'files', 'no-filename.dat')
+    var req = fs.createReadStream(filePath)
+    req.headers = {
+      'content-type': 'multipart/form-data; boundary=99999',
+      'content-length': fs.statSync(filePath).size
+    }
+
+    parser(req, null, function (err) {
+      onFinished(req, function () {
+        assert.ifError(err)
+        assert.equal(req.files.length, 1)
+        assert.equal(req.files[0].fieldname, 'fileField')
+        assert.equal(req.files[0].buffer.toString(), 'foo')
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Collabratec is sending upload requests that hit this edge case where they don't have a filename but do have the content-type application/octet-stream and so multer would simply ignore them.

This is fixed here and there is another pull request open for expressjs/multer to try and get this back into the main release so we don't have to maintain a fork.