### PR TITLE
update multer 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.2
+
+- Fix [CVE-2025-7338](https://www.cve.org/CVERecord?id=CVE-2025-7338) ([GHSA-fjgf-rc76-4x9p](https://github.com/expressjs/multer/security/advisories/GHSA-fjgf-rc76-4x9p))
+
+
 ## 2.0.1
 
 - Fix [CVE-2025-48997](https://www.cve.org/CVERecord?id=CVE-2025-48997) ([GHSA-g5hg-p3ph-g8qg](https://github.com/expressjs/multer/security/advisories/GHSA-g5hg-p3ph-g8qg))

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -101,6 +101,15 @@ function makeMiddleware (setup) {
 
     // handle files
     busboy.on('file', function (fieldname, fileStream, { filename, encoding, mimeType }) {
+      var pendingWritesIncremented = false
+
+      fileStream.on('error', function (err) {
+        if (pendingWritesIncremented) {
+          pendingWrites.decrement()
+        }
+        abortWithError(err)
+      })
+
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
 
       // filename is not required (https://tools.ietf.org/html/rfc1867) but if
@@ -134,17 +143,13 @@ function makeMiddleware (setup) {
         }
 
         var aborting = false
+        pendingWritesIncremented = true
         pendingWrites.increment()
 
         Object.defineProperty(file, 'stream', {
           configurable: true,
           enumerable: false,
           value: fileStream
-        })
-
-        fileStream.on('error', function (err) {
-          pendingWrites.decrement()
-          abortWithError(err)
         })
 
         fileStream.on('limit', function () {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",

--- a/test/no-filename.js
+++ b/test/no-filename.js
@@ -27,9 +27,9 @@ describe('File with no filename', function () {
     parser(req, null, function (err) {
       onFinished(req, function () {
         assert.ifError(err)
-        assert.equal(req.files.length, 1)
-        assert.equal(req.files[0].fieldname, 'fileField')
-        assert.equal(req.files[0].buffer.toString(), 'foo')
+        assert.strict.equal(req.files.length, 1)
+        assert.strict.equal(req.files[0].fieldname, 'fileField')
+        assert.strict.equal(req.files[0].buffer.toString(), 'foo')
         done()
       })
     })


### PR DESCRIPTION
Version 2.0.2 fixes [a sev:high issue](https://redirect.github.com/expressjs/multer/security/advisories/GHSA-fjgf-rc76-4x9p).

This PR brings over the commits from version 2.0.2 of multer. The v2 branch seemed to be quite far behind so I'm just doing this straight into master.

I fixed some lint issues - they didn't seem like they'd be new and I don't know whether I should do them.

I'll test this commit hash on dev before merging.