### PR TITLE
merge upstream changes from 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.2
+
+- Fix [CVE-2025-7338](https://www.cve.org/CVERecord?id=CVE-2025-7338) ([GHSA-fjgf-rc76-4x9p](https://github.com/expressjs/multer/security/advisories/GHSA-fjgf-rc76-4x9p))
+
+
 ## 2.0.1
 
 - Fix [CVE-2025-48997](https://www.cve.org/CVERecord?id=CVE-2025-48997) ([GHSA-g5hg-p3ph-g8qg](https://github.com/expressjs/multer/security/advisories/GHSA-g5hg-p3ph-g8qg))

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -101,6 +101,15 @@ function makeMiddleware (setup) {
 
     // handle files
     busboy.on('file', function (fieldname, fileStream, { filename, encoding, mimeType }) {
+      var pendingWritesIncremented = false
+
+      fileStream.on('error', function (err) {
+        if (pendingWritesIncremented) {
+          pendingWrites.decrement()
+        }
+        abortWithError(err)
+      })
+
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
 
       // don't attach to the files object, if there is no file
@@ -132,17 +141,13 @@ function makeMiddleware (setup) {
         }
 
         var aborting = false
+        pendingWritesIncremented = true
         pendingWrites.increment()
 
         Object.defineProperty(file, 'stream', {
           configurable: true,
           enumerable: false,
           value: fileStream
-        })
-
-        fileStream.on('error', function (err) {
-          pendingWrites.decrement()
-          abortWithError(err)
         })
 
         fileStream.on('limit', function () {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",

--- a/test/no-filename.js
+++ b/test/no-filename.js
@@ -27,9 +27,9 @@ describe('File with no filename', function () {
     parser(req, null, function (err) {
       onFinished(req, function () {
         assert.ifError(err)
-        assert.equal(req.files.length, 1)
-        assert.equal(req.files[0].fieldname, 'fileField')
-        assert.equal(req.files[0].buffer.toString(), 'foo')
+        assert.strict.equal(req.files.length, 1)
+        assert.strict.equal(req.files[0].fieldname, 'fileField')
+        assert.strict.equal(req.files[0].buffer.toString(), 'foo')
         done()
       })
     })


### PR DESCRIPTION
I needed a stable hash for the v2.0.2 changes for the Server Pro release.  
I created this by merging the upstream v2.0.2 into our fork.  
I added @Seinzu's commit https://github.com/overleaf/multer/pull/4/commits/f3d67942abd11454e63c71103743b840141297a2 to fix the lint errors.
Looking at the git log the commits are in the right order.

```
$ git remote add upstream git@github.com/expressjs/multer.git
$ git fetch upstream
remote: Enumerating objects: 255, done.
remote: Counting objects: 100% (123/123), done.
remote: Compressing objects: 100% (29/29), done.
remote: Total 255 (delta 105), reused 100 (delta 94), pack-reused 132 (from 3)
Receiving objects: 100% (255/255), 85.64 KiB | 851.00 KiB/s, done.
Resolving deltas: 100% (149/149), completed with 36 local objects.
From github.com:expressjs/multer
...
 * [new tag]         v2.0.2          -> v2.0.2
...
$ git switch -c bg-upstream-2-0-2
branch 'bg-upstream-2-0-2' set up to track 'master'.
Switched to a new branch 'bg-upstream-2-0-2'

$ git merge v2.0.2
Auto-merging lib/make-middleware.js
Merge made by the 'ort' strategy.
 CHANGELOG.md                |  5 +++++
 lib/make-middleware.js      | 15 ++++++++++-----
 package.json                |  2 +-
 test/express-integration.js | 42 ++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 58 insertions(+), 6 deletions(-)

$ git format-patch -1 f3d67942abd11454e63c71103743b840141297a2 
0001-Fix-lint-in-filename-tests.patch

$ git am 0001-Fix-lint-in-filename-tests.patch
Applying: Fix lint in filename tests

$ git push origin
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.
Delta compression using up to 12 threads
Compressing objects: 100% (1/1), done.
Writing objects: 100% (5/5), 1.87 KiB | 1.87 MiB/s, done.
Total 5 (delta 4), reused 4 (delta 4), pack-reused 0
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: 
remote: Create a pull request for 'bg-upstream-2-0-2' on GitHub by visiting:
remote:      https://github.com/overleaf/multer/pull/new/bg-upstream-2-0-2
remote: 
To github.com:overleaf/multer.git
 * [new branch]      bg-upstream-2-0-2 -> bg-upstream-2-0-2
```